### PR TITLE
Feature/pilot field

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -61,9 +61,9 @@ func createECToken(key *ecdsa.PrivateKey, username string) (string, error) {
 	// token claims
 	claims := make(jwt.MapClaims)
 	claims["iss"] = helpers.Config.Iss
-
 	claims["exp"] = time.Now().AddDate(0, 0, helpers.Config.ExpirationDays).Unix()
 	claims["sub"] = username
+	claims["pilot"] = helpers.Config.Username
 	token.Claims = claims
 
 	// create token

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/NBISweden/sda-uppmax-integration/helpers"
 	"github.com/NBISweden/sda-uppmax-integration/testHelpers"
+	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -82,9 +83,17 @@ func (suite *TestSuite) TestCreateECToken() {
 	err = helpers.NewConf(&helpers.Config)
 	assert.NoError(suite.T(), err)
 
-	_, err = createECToken(helpers.Config.ParsedKey, "username")
-
+	tokenString, err := createECToken(helpers.Config.ParsedKey, helpers.Config.EgaUser)
 	assert.NoError(suite.T(), err)
+
+	// Parse token to make sure it contains the correct information
+	token, _ := jwt.Parse(tokenString, func(tokenElixir *jwt.Token) (interface{}, error) { return nil, nil })
+	claims, _ := token.Claims.(jwt.MapClaims)
+
+	// Check that token includes the correct information
+	assert.Equal(suite.T(), helpers.Config.Username, claims["pilot"])
+	assert.Equal(suite.T(), helpers.Config.Iss, claims["iss"])
+	assert.Equal(suite.T(), helpers.Config.EgaUser, claims["sub"])
 
 	s3config, _, err := createS3Config("someuser")
 


### PR DESCRIPTION
This pull request add the `pilot` field to the token created by the uppmax integration service. In the current implementation, the name used for the `pilot` field is the same as the same as the username authenticating the user who makes the request: if the user `uppmax` tried to authenticate and take a token for a user, the field `pilot` will be set to `uppmax`.