### PR TITLE
Fix/new usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The `token` endpoint returns the following structure, if the user is authorised 
     "request_time": "<request_time>",
     "expiration": "<expiration>",
     "s3config": "<base64_encoded_s3config>"
+    "crypt4gh_key": "<base64_encoded_crypt4gh_pub_key>"
 }
 ```
 The `s3config` file is base64 encoded in the response described above.
@@ -65,5 +66,11 @@ kubectl -n lega create secret generic <secret_name> --from-file=<key_path> --fro
 ```
 The names of the files should be added in the values files in `jwt.keyName` and `crypt4ghKey` respectively in the `values.yaml`. Populate the rest of the `values.yaml` file with the correct values and then install using the local copy of the helm charts with
 ```sh
-helm install --namespace lega uppmax charts/uppmax-integration
+helm install --namespace <namespace_name> uppmax charts/uppmax-integration
+```
+while to install using the published charts use
+```sh
+helm repo add uppmax https://nbisweden.github.io/sda-uppmax-integration/
+helm repo update
+helm install --namespace <namespace_name> uppmax charts/uppmax-integration
 ```

--- a/token/token.go
+++ b/token/token.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	b64 "encoding/base64"
@@ -88,8 +89,8 @@ func createS3Config(username string) (s3config string, expiration string, err er
 	}
 
 	expiration = time.Now().AddDate(0, 0, helpers.Config.ExpirationDays).Format("01-02-2006 15:04:05")
-	s3config += "secret_key = " + username + "\naccess_key = " + username + "\naccess_token = " + token +
-		"\nhost_base = " + helpers.Config.S3URL + "\nhost_bucket = " + helpers.Config.S3URL
+	s3config += "secret_key = " + strings.ReplaceAll(username, "@", "_") + "\naccess_key = " + strings.ReplaceAll(username, "@", "_") +
+		"\naccess_token = " + token + "\nhost_base = " + helpers.Config.S3URL + "\nhost_bucket = " + helpers.Config.S3URL
 
 	s3config = b64.StdEncoding.EncodeToString([]byte(s3config))
 


### PR DESCRIPTION
The usernames from cega are currently the emails. Similarly to the auth service, the username needs to change, by replacing the `@` character with `_`. This PR fixes this issue and updates the instructions for deploying the service using helm.