### PR TITLE
Upgrade chart

### DIFF
--- a/charts/uppmax-integration/Chart.yaml
+++ b/charts/uppmax-integration/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/uppmax-integration/values.yaml
+++ b/charts/uppmax-integration/values.yaml
@@ -33,7 +33,7 @@ image:
   repository: harbor.nbis.se/uppmax/integration
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.1"
+  tag: "0.1.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
The changes introduced in [this PR](https://github.com/NBISweden/sda-uppmax-integration/pull/43) are not reflected in the docker image referenced there. A new image has been build and pushed to harbor and this PR updates the version of the image and the chart, in order to incorporate the latest changes.

After this PR is merged, the [deployment PR](https://github.com/NBISweden/LocalEGA-SE-Deployment/pull/613) should also be updated and deployed to the cluster.