### PR TITLE
sdaDevs as dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - dbampalikis
-      - jbygdell
-      - norling
-      - aaperis
-      - kostas-kou
+      - "nbisweden/sda-developers"
   - package-ecosystem: docker
     directory: ./
     schedule:
@@ -21,8 +17,4 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - dbampalikis
-      - jbygdell
-      - norling
-      - aaperis
-      - kostas-kou
+      - "nbisweden/sda-developers"


### PR DESCRIPTION
Assuming that the repo is assigned to the team, this fixes https://github.com/NBISweden/sda-uppmax-integration/pull/60#issuecomment-1849813734 .