### PR TITLE
Hotfix/add kid

### DIFF
--- a/charts/uppmax-integration/values.yaml
+++ b/charts/uppmax-integration/values.yaml
@@ -33,7 +33,7 @@ image:
   repository: harbor.nbis.se/uppmax/integration
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.2"
+  tag: "2024-04-03"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/token/token.go
+++ b/token/token.go
@@ -49,6 +49,7 @@ func createECToken(key *ecdsa.PrivateKey, username string) (string, error) {
 	token := jwt.New(jwt.SigningMethodES256)
 	// token headers
 	token.Header["alg"] = "ES256"
+	token.Header["kid"] = "sda"
 	// token claims
 	claims := make(jwt.MapClaims)
 	claims["iss"] = helpers.Config.Iss


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR does not close any issue but the bug was found by doing [this issue](https://app.zenhub.com/workspaces/giant-sloth-6041ec3fd9297d0016321f73/issues/gh/nbisweden/localega-se-deployment/728).


**Description**
The upload from bianca was failing because of the token which was sent from the uppmax integration service and it did not have any `kid` in the header which in turn was rejected during the token authentication. 

**How to test**
One can test by following the instructions [here](https://scilifelab.atlassian.net/wiki/spaces/GS/pages/2791669834/EGA-Integrations) assuming that the user belongs to a delivery project and that has uppmax credentials